### PR TITLE
Add latency logging to object detection and tracking

### DIFF
--- a/Runtime/ARInstructionManager.cs
+++ b/Runtime/ARInstructionManager.cs
@@ -185,9 +185,12 @@ namespace RecognX
 
         public async Task CaptureAndLocalize()
         {
+            float startTime = Time.realtimeSinceStartup;
             var activeIds = sessionManager.GetAllRelevantYoloIdsForCurrentStep();
             Debug.Log(activeIds);
             var objects = await discoveryManager.LocateObjectsAsync(activeIds);
+            float totalDuration = Time.realtimeSinceStartup - startTime;
+            Debug.Log($"[Latency] CaptureAndLocalize total {totalDuration * 1000f} ms");
             HandleObjectsLocalized(objects);
         }
 
@@ -242,10 +245,16 @@ namespace RecognX
 
         public async Task TrackStepAsync()
         {
+            float startTime = Time.realtimeSinceStartup;
             var cameraTexture = DiscoveryManager.CaptureCameraTextureAsync();
+            float backendStart = Time.realtimeSinceStartup;
             var response = await backendService.SubmitLiveFrameAsync(cameraTexture);
+            float backendDuration = Time.realtimeSinceStartup - backendStart;
+            Debug.Log($"[Latency] SubmitLiveFrameAsync took {backendDuration * 1000f} ms");
 
+            float totalDuration = Time.realtimeSinceStartup - startTime;
             Debug.Log($"📩 GPT Feedback: {response.response}");
+            Debug.Log($"[Latency] TrackStepAsync total {totalDuration * 1000f} ms");
             Debug.Log(
                 $"🧭 Step: {response.step_number} | ✅ Completed: {response.step_completed} | 🎯 Task Done: {response.task_completed}");
 

--- a/Runtime/DiscoveryManager.cs
+++ b/Runtime/DiscoveryManager.cs
@@ -47,15 +47,27 @@ namespace RecognX
 
         public async Task<List<LocalizedObject>> LocateObjectsAsync(List<int> activeYoloIds)
         {
+            float startTime = Time.realtimeSinceStartup;
             Texture2D tex = CaptureCameraTextureAsync();
             cameraPosAtCapture = arCamera.transform.position;
             cameraRotAtCapture = arCamera.transform.rotation;
 
+            float backendStart = Time.realtimeSinceStartup;
             List<YoloDetection> detections = await backendService.DetectObjectsAsync(tex, activeYoloIds);
+            float backendDuration = Time.realtimeSinceStartup - backendStart;
+            Debug.Log($"[Latency] DetectObjectsAsync took {backendDuration * 1000f} ms");
+
             foreach (var detection in detections)
                 Debug.Log(
                     $"Detected {detection.class_name} (YOLO ID: {detection.yoloId}) @ confidence {detection.confidence}");
+
+            float raycastStart = Time.realtimeSinceStartup;
             var results = HandleDetections(detections, tex.width, tex.height);
+            float raycastDuration = Time.realtimeSinceStartup - raycastStart;
+            Debug.Log($"[Latency] Raycasting took {raycastDuration * 1000f} ms");
+
+            float totalDuration = Time.realtimeSinceStartup - startTime;
+            Debug.Log($"[Latency] LocateObjectsAsync total {totalDuration * 1000f} ms");
             return results;
         }
 


### PR DESCRIPTION
## Summary
- log timing in `CaptureAndLocalize` and `TrackStepAsync`
- capture timing details in `DiscoveryManager.LocateObjectsAsync`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684955c468fc83258db21b27d67547c2